### PR TITLE
change dependencies order to make css always last

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,7 @@
     "parts": [
         {
             "name": "ep_themes_ext",
+            "pre": ["ep_inline_toolbar", "ep_*"],
             "hooks": {
                 "clientVars": "ep_themes_ext/serverHooks:clientVars"
             },


### PR DESCRIPTION
added ` "pre": ["ep_inline_toolbar", "ep_*"], ` to` ep.json` so that themes would always be one of the last hooks to be executed so that custom css could override other plugins css files